### PR TITLE
Add controls layout and responsive dashboard

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -1,0 +1,18 @@
+.dashboard {
+    padding: 10px;
+}
+.controls {
+    display: flex;
+    justify-content: space-evenly;
+    margin-bottom: 10px;
+}
+.plots {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+}
+@media (max-aspect-ratio: 1/1) {
+    .plots {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add assets folder with responsive CSS
- wrap app layout in a `.dashboard` container
- include four control buttons and stores
- configure graphs as static plots and place them in a `.plots` container
- extend callback to toggle all control signals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*