### PR TITLE
Limit SSE backlog to 1000 samples

### DIFF
--- a/app.py
+++ b/app.py
@@ -371,6 +371,12 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         print("[SSE] Client connected.")
 
         def generate():
+            # Drop all but the newest 1000 samples so the client isn't flooded
+            while event_q.qsize() > 1000:
+                try:
+                    event_q.get_nowait()
+                except Exception:
+                    break
             batch: List[Dict[str, float]] = []
             while True:
                 item = event_q.get()

--- a/sse_server.py
+++ b/sse_server.py
@@ -21,6 +21,12 @@ app = Flask(__name__)
 @app.route("/events")
 def sse():  # type: ignore
     def generate():
+        # Drop stale samples so new clients only receive the most recent ones
+        while EVENT_Q.qsize() > 1000:
+            try:
+                EVENT_Q.get_nowait()
+            except Exception:
+                break
         while True:
             data = EVENT_Q.get()
             yield f"data:{json.dumps(data)}\n\n"


### PR DESCRIPTION
## Summary
- flush old data when a client connects to the SSE endpoint
- apply the same logic in the standalone SSE server

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*