### PR TITLE
Serve Dash assets locally for offline use

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,16 @@ def start_udp_listener(
 
 
 def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> dash.Dash:
-    app = dash.Dash(__name__)
+    """Create and configure the Dash application."""
+    # Serve JS/CSS assets locally so the dashboard works without Internet
+    # access. ``serve_locally`` is available on newer Dash versions but we
+    # also fall back to the older ``css.config``/``scripts.config`` flags
+    # for backwards compatibility.
+    app = dash.Dash(__name__, serve_locally=True)
+    if hasattr(app, "css") and hasattr(app.css, "config"):
+        app.css.config.serve_locally = True
+    if hasattr(app, "scripts") and hasattr(app.scripts, "config"):
+        app.scripts.config.serve_locally = True
 
     app.layout = html.Div(
         className="dashboard",

--- a/app_test.py
+++ b/app_test.py
@@ -37,7 +37,12 @@ def load_csv(path: str = LOG_FILE) -> pd.DataFrame:
 # Dash App
 # -----------------------------------------------------------------------------
 
-app = dash.Dash(__name__)
+# Serve assets locally so the offline viewer does not depend on the network.
+app = dash.Dash(__name__, serve_locally=True)
+if hasattr(app, "css") and hasattr(app.css, "config"):
+    app.css.config.serve_locally = True
+if hasattr(app, "scripts") and hasattr(app.scripts, "config"):
+    app.scripts.config.serve_locally = True
 
 app.layout = html.Div(
     [

--- a/frontend_dash.py
+++ b/frontend_dash.py
@@ -13,7 +13,14 @@ import plotly.graph_objs as go
 from dash_extensions import EventSource
 import json
 
-app = dash.Dash(__name__)
+# Serve Dash assets locally so this demo works without Internet access. This
+# uses ``serve_locally=True`` for modern versions and falls back to the old
+# ``css.config``/``scripts.config`` flags if present.
+app = dash.Dash(__name__, serve_locally=True)
+if hasattr(app, "css") and hasattr(app.css, "config"):
+    app.css.config.serve_locally = True
+if hasattr(app, "scripts") and hasattr(app.scripts, "config"):
+    app.scripts.config.serve_locally = True
 
 app.layout = html.Div(
     [


### PR DESCRIPTION
## Summary
- configure Dash apps to serve assets locally so the web interface can be used offline

## Testing
- `python -m py_compile app.py frontend_dash.py app_test.py`