### PR TITLE
Fix plots layout on iPad

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -35,10 +35,18 @@
 .plots {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 20px;
 }
-@media (max-aspect-ratio: 1/1) {
+.plots .dash-graph {
+    flex: 1 1 45%;
+    min-width: 0;
+}
+@media (max-width: 1024px) {
     .plots {
         flex-direction: column;
+    }
+    .plots .dash-graph {
+        flex-basis: 100%;
     }
 }


### PR DESCRIPTION
## Summary
- make the dashboard plots wrap and resize on smaller screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*