### PR TITLE
Use colors for state and press-to-hold zero button

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -32,6 +32,10 @@
 .controls button:active {
     background: linear-gradient(#e0e0e0, #d0d0d0);
 }
+
+.controls button.on {
+    background: lightgreen;
+}
 .plots {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Summary
- remove numeric state labels from buttons
- style buttons using light green when active
- implement clientside callback to send `zero` command while button is held
- update server callback for new button logic

## Testing
- `python -m py_compile app.py frontend_dash.py app_test.py data_handler.py listener.py sse_server.py main.py`