### PR TITLE
Improve plot styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -213,8 +213,17 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                 go.Scatter(x=[], y=[], mode="lines", name="ankle_angle")
                             ],
                             layout=dict(
-                                yaxis=dict(range=[-60, 60]),
-                                title="Ankle Angle (deg)",
+                                yaxis=dict(
+                                    range=[-60, 60],
+                                    title="Ankle Angle (deg)",
+                                    gridcolor="#cccccc",
+                                    tickfont=dict(size=12),
+                                ),
+                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=12)),
+                                title=None,
+                                plot_bgcolor="rgba(0,0,0,0)",
+                                paper_bgcolor="rgba(0,0,0,0)",
+                                font=dict(family="IBM Plex Sans Condensed", size=14),
                             ),
                         ),
                         config={"displayModeBar": False, "staticPlot": True},
@@ -227,8 +236,14 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                 for i in range(1, 9)
                             ],
                             layout=dict(
-                                yaxis=dict(range=[0, 1000]),
-                                title="Pressure",
+                                yaxis=dict(
+                                    range=[0, 1000],
+                                    title="Pressure (N)",
+                                    gridcolor="#cccccc",
+                                    tickfont=dict(size=12),
+                                ),
+                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=12)),
+                                title=None,
                                 legend=dict(
                                     orientation="h",
                                     yanchor="bottom",
@@ -237,6 +252,9 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                     x=0,
                                 ),
                                 margin=dict(t=60),
+                                plot_bgcolor="rgba(0,0,0,0)",
+                                paper_bgcolor="rgba(0,0,0,0)",
+                                font=dict(family="IBM Plex Sans Condensed", size=14),
                             ),
                         ),
                         config={"displayModeBar": False, "staticPlot": True},

--- a/app_test.py
+++ b/app_test.py
@@ -69,10 +69,24 @@ def update_figures(_):  # noqa: D401
 
     # Ankle angle
     fig_ankle = go.Figure()
-    fig_ankle.add_trace(go.Scatter(x=times, y=df["ankle_angle"], mode="lines", name="ankle_angle"))
-    fig_ankle.update_yaxes(range=[-60, 60])
-    fig_ankle.update_xaxes(range=[times[0], times[-1]])
-    fig_ankle.update_layout(title="Ankle Angle (deg)")
+    fig_ankle.add_trace(
+        go.Scatter(x=times, y=df["ankle_angle"], mode="lines", name="ankle_angle")
+    )
+    fig_ankle.update_yaxes(
+        range=[-60, 60],
+        title="Ankle Angle (deg)",
+        gridcolor="#cccccc",
+        tickfont=dict(size=12),
+    )
+    fig_ankle.update_xaxes(
+        range=[times[0], times[-1]], gridcolor="#cccccc", tickfont=dict(size=12)
+    )
+    fig_ankle.update_layout(
+        title=None,
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font=dict(family="IBM Plex Sans Condensed", size=14),
+    )
 
     # Pressures
     fig_press = go.Figure()
@@ -80,9 +94,22 @@ def update_figures(_):  # noqa: D401
         key = f"pressure_{i}"
         if key in df:
             fig_press.add_trace(go.Scatter(x=times, y=df[key], mode="lines", name=key))
-    fig_press.update_yaxes(range=[0, 1000])
-    fig_press.update_xaxes(range=[times[0], times[-1]])
-    fig_press.update_layout(title="Plantar Pressures")
+    fig_press.update_yaxes(
+        range=[0, 1000],
+        title="Pressure (N)",
+        gridcolor="#cccccc",
+        tickfont=dict(size=12),
+    )
+    fig_press.update_xaxes(
+        range=[times[0], times[-1]], gridcolor="#cccccc", tickfont=dict(size=12)
+    )
+    fig_press.update_layout(
+        title=None,
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        legend=dict(orientation="h"),
+        font=dict(family="IBM Plex Sans Condensed", size=14),
+    )
 
     return fig_ankle, fig_press
 

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -4,6 +4,11 @@
     padding: 10px;
 }
 
+body {
+    background: transparent;
+    font-family: 'IBM Plex Sans Condensed', sans-serif;
+}
+
 .dashboard h2 {
     text-align: center;
     font-family: 'IBM Plex Sans Condensed', sans-serif;
@@ -45,6 +50,10 @@
 .plots .dash-graph {
     flex: 1 1 45%;
     min-width: 0;
+    padding: 10px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 @media (max-width: 1024px) {
     .plots {

--- a/frontend_dash.py
+++ b/frontend_dash.py
@@ -35,7 +35,22 @@ app.layout = html.Div(
             },
         ),
         dcc.Graph(
-            id="angle", figure=go.Figure(layout=dict(yaxis=dict(range=[-60, 60])))
+            id="angle",
+            figure=go.Figure(
+                layout=dict(
+                    yaxis=dict(
+                        range=[-60, 60],
+                        title="Ankle Angle (deg)",
+                        gridcolor="#cccccc",
+                        tickfont=dict(size=12),
+                    ),
+                    xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=12)),
+                    title=None,
+                    plot_bgcolor="rgba(0,0,0,0)",
+                    paper_bgcolor="rgba(0,0,0,0)",
+                    font=dict(family="IBM Plex Sans Condensed", size=14),
+                )
+            ),
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- modernise graph styling to remove grey backgrounds and show grey grid lines
- style ticks and titles for better readability
- add drop-shadow containers for each plot
- update offline viewer and demo to share the new look

## Testing
- `pytest -q` *(fails: No module named 'pandas')*