### PR TITLE
Improve plot background and dock styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,7 +202,6 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             dcc.Store(id="k-state", data=0),
             dcc.Interval(id="zero-interval", interval=100, n_intervals=0),
             EventSource(id="es", url="/events"),
-            html.Hr(),
             html.Div(
                 className="plots",
                 children=[
@@ -221,8 +220,8 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                 ),
                                 xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=12)),
                                 title=None,
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
+                                plot_bgcolor="rgba(240,240,240,0.4)",
+                                paper_bgcolor="rgba(240,240,240,0.4)",
                                 font=dict(family="IBM Plex Sans Condensed", size=14),
                             ),
                         ),
@@ -238,7 +237,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                             layout=dict(
                                 yaxis=dict(
                                     range=[0, 1000],
-                                    title="Pressure (N)",
+                                    title="Pressure",
                                     gridcolor="#cccccc",
                                     tickfont=dict(size=12),
                                 ),
@@ -252,8 +251,8 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                     x=0,
                                 ),
                                 margin=dict(t=60),
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
+                                plot_bgcolor="rgba(240,240,240,0.4)",
+                                paper_bgcolor="rgba(240,240,240,0.4)",
                                 font=dict(family="IBM Plex Sans Condensed", size=14),
                             ),
                         ),

--- a/app_test.py
+++ b/app_test.py
@@ -83,8 +83,8 @@ def update_figures(_):  # noqa: D401
     )
     fig_ankle.update_layout(
         title=None,
-        plot_bgcolor="rgba(0,0,0,0)",
-        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(240,240,240,0.4)",
+        paper_bgcolor="rgba(240,240,240,0.4)",
         font=dict(family="IBM Plex Sans Condensed", size=14),
     )
 
@@ -96,7 +96,7 @@ def update_figures(_):  # noqa: D401
             fig_press.add_trace(go.Scatter(x=times, y=df[key], mode="lines", name=key))
     fig_press.update_yaxes(
         range=[0, 1000],
-        title="Pressure (N)",
+        title="Pressure",
         gridcolor="#cccccc",
         tickfont=dict(size=12),
     )
@@ -105,8 +105,8 @@ def update_figures(_):  # noqa: D401
     )
     fig_press.update_layout(
         title=None,
-        plot_bgcolor="rgba(0,0,0,0)",
-        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(240,240,240,0.4)",
+        paper_bgcolor="rgba(240,240,240,0.4)",
         legend=dict(orientation="h"),
         font=dict(family="IBM Plex Sans Condensed", size=14),
     )

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -61,7 +61,7 @@ body {
     padding: 10px;
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.8);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
 }
 @media (max-width: 1024px) {
     .plots {

--- a/frontend_dash.py
+++ b/frontend_dash.py
@@ -46,8 +46,8 @@ app.layout = html.Div(
                     ),
                     xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=12)),
                     title=None,
-                    plot_bgcolor="rgba(0,0,0,0)",
-                    paper_bgcolor="rgba(0,0,0,0)",
+                    plot_bgcolor="rgba(240,240,240,0.4)",
+                    paper_bgcolor="rgba(240,240,240,0.4)",
                     font=dict(family="IBM Plex Sans Condensed", size=14),
                 )
             ),


### PR DESCRIPTION
## Summary
- remove horizontal rule below buttons
- darken the floating dock shadow
- show plots with a faint grey background
- drop units from pressure axis labels

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*