### PR TITLE
UI polish for buttons dock

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,12 +192,17 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         children=[
             html.H2("AFO Dashboard"),
             html.Div(
-                className="controls",
+                className="controls-dock",
                 children=[
-                    html.Button("zero", id="zero-btn", n_clicks=0),
-                    html.Button("motor", id="motor-btn", n_clicks=0),
-                    html.Button("assist", id="assist-btn", n_clicks=0),
-                    html.Button("k", id="k-btn", n_clicks=0),
+                    html.Div(
+                        className="controls",
+                        children=[
+                            html.Button("zero", id="zero-btn", n_clicks=0),
+                            html.Button("motor", id="motor-btn", n_clicks=0),
+                            html.Button("assist", id="assist-btn", n_clicks=0),
+                            html.Button("k", id="k-btn", n_clicks=0),
+                        ],
+                    )
                 ],
             ),
             dcc.Store(id="zero-state", data=0),
@@ -205,7 +210,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             dcc.Store(id="assist-state", data=0),
             dcc.Store(id="k-state", data=0),
             dcc.Interval(id="zero-interval", interval=100, n_intervals=0),
-            EventSource(id="es", url="/events"),
+            EventSource(id="es", url="/events", style={"display": "none"}),
             html.Div(
                 className="plots",
                 children=[

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -13,10 +13,17 @@ body {
     text-align: center;
     font-family: 'IBM Plex Sans Condensed', sans-serif;
 }
+.controls-dock {
+    padding: 10px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
+    margin-bottom: 20px;
+}
+
 .controls {
     display: flex;
     justify-content: space-evenly;
-    margin-bottom: 10px;
 }
 
 .controls button {
@@ -24,7 +31,7 @@ body {
     border: 1px solid #bbb;
     border-radius: 12px;
     background: linear-gradient(#f5f5f5, #e0e0e0);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: none;
     font-size: 16px;
     cursor: pointer;
     transition: none;


### PR DESCRIPTION
## Summary
- wrap control buttons in a new `controls-dock` container styled like the plot panels
- hide the `EventSource` component so it doesn't render a stray element
- remove button shadow and share 'floating dock' style

## Testing
- `python -m py_compile app.py frontend_dash.py app_test.py data_handler.py listener.py sse_server.py main.py`