### PR TITLE
Fix EventSource CSS handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,7 +211,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             dcc.Store(id="k-state", data=0),
             html.Div(id="signal-sent", style={"display": "none"}),
             dcc.Interval(id="zero-interval", interval=100, n_intervals=0),
-            EventSource(id="es", url="/events", style={"display": "none"}),
+            html.Div(EventSource(id="es", url="/events"), style={"display": "none"}),
             html.Div(
                 className="plots",
                 children=[

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -78,3 +78,7 @@ body {
         flex-basis: 100%;
     }
 }
+
+#es {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- wrap EventSource component inside a hidden div
- hide the EventSource element with CSS

## Testing
- `python -m py_compile app.py data_handler.py listener.py main.py frontend_dash.py sse_server.py app_test.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'yaml')*