### PR TITLE
Fix button dock position

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -16,10 +16,7 @@ body {
 .controls-dock {
     padding: 10px;
     border-radius: 12px;
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    z-index: 1000;
+    margin-bottom: 20px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
 }
 


### PR DESCRIPTION
## Summary
- keep the four control buttons above the plots by removing the floating styling

## Testing
- `python -m py_compile app.py frontend_dash.py data_handler.py listener.py sse_server.py app_test.py main.py`