### PR TITLE
Fix Dash server host to localhost

### DIFF
--- a/app.py
+++ b/app.py
@@ -649,7 +649,7 @@ if __name__ == "__main__":
     try:
         dash_app = build_dash_app(cfg, data_queue)
         dash_app.run(
-            host="192.168.7.15",
+            host="127.0.0.1",
             port=8050,
             debug=True,
             use_reloader=False,


### PR DESCRIPTION
## Summary
- run Dash server on 127.0.0.1 instead of a hard-coded IP

## Testing
- `python -m py_compile app.py listener.py main.py app_test.py data_handler.py frontend_dash.py sse_server.py`
- *(fails: ModuleNotFoundError: No module named 'yaml' when running app)*