### PR TITLE
Add swipeable tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,105 +292,171 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             dcc.Interval(id="zero-interval", interval=100, n_intervals=0),
             html.Div(EventSource(id="es", url="/events"), style={"display": "none"}),
             html.Div(
-                className="plots",
+                className="swipe-container",
                 children=[
-                    dcc.Graph(
-                        id="torque",
-                        figure=go.Figure(
-                            data=[go.Scatter(x=[], y=[], mode="lines", name="actual_torque")],
-                            layout=dict(
-                                yaxis=dict(
-                                    range=[-5, 15],
-                                    title="Actual Torque",
-                                    gridcolor="#cccccc",
-                                    tickfont=dict(size=16),
-                                ),
-                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=16)),
-                                title=None,
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
-                                font=dict(family="IBM Plex Sans Condensed", size=18),
-                            ),
-                        ),
-                        config={"displayModeBar": False, "staticPlot": True},
+                    html.Div(
+                        className="swipe-page",
+                        children=[
+                            html.Div(
+                                className="plots",
+                                children=[
+                                    dcc.Graph(
+                                        id="torque",
+                                        figure=go.Figure(
+                                            data=[
+                                                go.Scatter(
+                                                    x=[],
+                                                    y=[],
+                                                    mode="lines",
+                                                    name="actual_torque",
+                                                )
+                                            ],
+                                            layout=dict(
+                                                yaxis=dict(
+                                                    range=[-5, 15],
+                                                    title="Actual Torque",
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                xaxis=dict(
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                title=None,
+                                                plot_bgcolor="rgba(0,0,0,0)",
+                                                paper_bgcolor="rgba(0,0,0,0)",
+                                                font=dict(
+                                                    family="IBM Plex Sans Condensed",
+                                                    size=18,
+                                                ),
+                                            ),
+                                        ),
+                                        config={"displayModeBar": False, "staticPlot": True},
+                                    ),
+                                    dcc.Graph(
+                                        id="ankle",
+                                        figure=go.Figure(
+                                            data=[
+                                                go.Scatter(
+                                                    x=[],
+                                                    y=[],
+                                                    mode="lines",
+                                                    name="ankle_angle",
+                                                )
+                                            ],
+                                            layout=dict(
+                                                yaxis=dict(
+                                                    range=[-60, 60],
+                                                    title="Ankle Angle (deg)",
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                xaxis=dict(
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                title=None,
+                                                plot_bgcolor="rgba(0,0,0,0)",
+                                                paper_bgcolor="rgba(0,0,0,0)",
+                                                font=dict(
+                                                    family="IBM Plex Sans Condensed",
+                                                    size=18,
+                                                ),
+                                            ),
+                                        ),
+                                        config={"displayModeBar": False, "staticPlot": True},
+                                    ),
+                                ],
+                            )
+                        ],
                     ),
-                    dcc.Graph(
-                        id="ankle",
-                        figure=go.Figure(
-                            data=[
-                                go.Scatter(x=[], y=[], mode="lines", name="ankle_angle")
-                            ],
-                            layout=dict(
-                                yaxis=dict(
-                                    range=[-60, 60],
-                                    title="Ankle Angle (deg)",
-                                    gridcolor="#cccccc",
-                                    tickfont=dict(size=16),
-                                ),
-                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=16)),
-                                title=None,
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
-                                font=dict(family="IBM Plex Sans Condensed", size=18),
-                            ),
-                        ),
-                        config={"displayModeBar": False, "staticPlot": True},
-                    ),
-                    dcc.Graph(
-                        id="press",
-                        figure=go.Figure(
-                            data=[
-                                go.Scatter(x=[], y=[], mode="lines", name=f"pressure_{i}")
-                                for i in range(1, 9)
-                            ],
-                            layout=dict(
-                                yaxis=dict(
-                                    range=[0, 1000],
-                                    title="Pressure",
-                                    gridcolor="#cccccc",
-                                    tickfont=dict(size=16),
-                                ),
-                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=16)),
-                                title=None,
-                                legend=dict(
-                                    orientation="h",
-                                    yanchor="bottom",
-                                    y=1.02,
-                                    xanchor="left",
-                                    x=0,
-                                ),
-                                margin=dict(t=60),
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
-                                font=dict(family="IBM Plex Sans Condensed", size=18),
-                            ),
-                        ),
-                        config={"displayModeBar": False, "staticPlot": True},
-                    ),
-                    dcc.Graph(
-                        id="imu",
-                        figure=go.Figure(
-                            data=[
-                                go.Scatter(x=[], y=[], mode="lines", name=f"imu_{i}")
-                                for i in range(1, 4)
-                            ],
-                            layout=dict(
-                                yaxis=dict(
-                                    range=[-3, 3],
-                                    title="IMU",
-                                    gridcolor="#cccccc",
-                                    tickfont=dict(size=16),
-                                ),
-                                xaxis=dict(gridcolor="#cccccc", tickfont=dict(size=16)),
-                                title=None,
-                                legend=dict(orientation="h"),
-                                margin=dict(t=60),
-                                plot_bgcolor="rgba(0,0,0,0)",
-                                paper_bgcolor="rgba(0,0,0,0)",
-                                font=dict(family="IBM Plex Sans Condensed", size=18),
-                            ),
-                        ),
-                        config={"displayModeBar": False, "staticPlot": True},
+                    html.Div(
+                        className="swipe-page",
+                        children=[
+                            html.Div(
+                                className="plots",
+                                children=[
+                                    dcc.Graph(
+                                        id="press",
+                                        figure=go.Figure(
+                                            data=[
+                                                go.Scatter(
+                                                    x=[],
+                                                    y=[],
+                                                    mode="lines",
+                                                    name=f"pressure_{i}",
+                                                )
+                                                for i in range(1, 9)
+                                            ],
+                                            layout=dict(
+                                                yaxis=dict(
+                                                    range=[0, 1000],
+                                                    title="Pressure",
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                xaxis=dict(
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                title=None,
+                                                legend=dict(
+                                                    orientation="h",
+                                                    yanchor="bottom",
+                                                    y=1.02,
+                                                    xanchor="left",
+                                                    x=0,
+                                                ),
+                                                margin=dict(t=60),
+                                                plot_bgcolor="rgba(0,0,0,0)",
+                                                paper_bgcolor="rgba(0,0,0,0)",
+                                                font=dict(
+                                                    family="IBM Plex Sans Condensed",
+                                                    size=18,
+                                                ),
+                                            ),
+                                        ),
+                                        config={"displayModeBar": False, "staticPlot": True},
+                                    ),
+                                    dcc.Graph(
+                                        id="imu",
+                                        figure=go.Figure(
+                                            data=[
+                                                go.Scatter(
+                                                    x=[],
+                                                    y=[],
+                                                    mode="lines",
+                                                    name=f"imu_{i}",
+                                                )
+                                                for i in range(1, 4)
+                                            ],
+                                            layout=dict(
+                                                yaxis=dict(
+                                                    range=[-3, 3],
+                                                    title="IMU",
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                xaxis=dict(
+                                                    gridcolor="#cccccc",
+                                                    tickfont=dict(size=16),
+                                                ),
+                                                title=None,
+                                                legend=dict(orientation="h"),
+                                                margin=dict(t=60),
+                                                plot_bgcolor="rgba(0,0,0,0)",
+                                                paper_bgcolor="rgba(0,0,0,0)",
+                                                font=dict(
+                                                    family="IBM Plex Sans Condensed",
+                                                    size=18,
+                                                ),
+                                            ),
+                                        ),
+                                        config={"displayModeBar": False, "staticPlot": True},
+                                    ),
+                                ],
+                            )
+                        ],
                     ),
                 ],
             ),

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -81,3 +81,16 @@ body {
 #es {
     display: none;
 }
+
+.swipe-container {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+}
+
+.swipe-page {
+    flex: 0 0 100%;
+    scroll-snap-align: start;
+}
+


### PR DESCRIPTION
## Summary
- split graphs into two swipeable tabs: torque/ankle and pressure/IMU
- style swipe container with scroll snap

## Testing
- `python -m py_compile app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*