### PR TITLE
Improve tab layout styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,6 +310,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                 children=[
                                     dcc.Graph(
                                         id="torque",
+                                        style={"height": "360px"},
                                         figure=go.Figure(
                                             data=[
                                                 go.Scatter(
@@ -343,6 +344,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                     ),
                                     dcc.Graph(
                                         id="ankle",
+                                        style={"height": "360px"},
                                         figure=go.Figure(
                                             data=[
                                                 go.Scatter(
@@ -386,6 +388,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                 children=[
                                     dcc.Graph(
                                         id="press",
+                                        style={"height": "360px"},
                                         figure=go.Figure(
                                             data=[
                                                 go.Scatter(
@@ -428,6 +431,7 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                     ),
                                     dcc.Graph(
                                         id="imu",
+                                        style={"height": "360px"},
                                         figure=go.Figure(
                                             data=[
                                                 go.Scatter(

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -68,7 +68,7 @@ body {
     border-radius: 12px;
     background: transparent;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
-    height: 380px; /* bigger to avoid clipping the shadow */
+    height: 380px; /* 10px padding around a 360px plot */
 }
 @media (max-width: 1024px) {
     .plots {
@@ -91,15 +91,24 @@ body {
 
 .tab-buttons button {
     flex: 1 1 50%;
-    padding: 8px 12px;
-    border: none;
-    background: #ddd;
+    padding: 10px 16px;
+    margin: 0 4px;
+    border: 1px solid transparent;
+    border-radius: 20px;
+    background: #f2f3f5;
     cursor: pointer;
     font-size: 16px;
+    transition: background 0.2s, box-shadow 0.2s;
+}
+
+.tab-buttons button:hover {
+    background: #e4e5e7;
 }
 
 .tab-buttons button.active {
-    background: #bbb;
+    background: #ffffff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    border-color: #ccc;
 }
 
 .swipe-container {
@@ -117,5 +126,10 @@ body {
 .swipe-page {
     flex: 0 0 100%;
     scroll-snap-align: start;
+    padding: 20px;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    margin-bottom: 10px;
 }
 


### PR DESCRIPTION
## Summary
- tweak graph height so container has extra space for shadow
- give tab page areas a white rounded background
- style the tab selection buttons with a softer look

## Testing
- `python -m py_compile $(git ls-files '*.py')`