### PR TITLE
Revamp controls styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,10 +276,10 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                     html.Div(
                         className="controls",
                         children=[
-                            html.Button("zero", id="zero-btn", n_clicks=0),
-                            html.Button("motor", id="motor-btn", n_clicks=0),
-                            html.Button("assist", id="assist-btn", n_clicks=0),
-                            html.Button("k", id="k-btn", n_clicks=0),
+                            html.Button("⚪", id="zero-btn", n_clicks=0),
+                            html.Button("⚪", id="motor-btn", n_clicks=0),
+                            html.Button("⚪", id="assist-btn", n_clicks=0),
+                            html.Button("⚪", id="k-btn", n_clicks=0),
                         ],
                     )
                 ],
@@ -484,11 +484,12 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         """
         function(n) {
             var active = document.getElementById('zero-btn').matches(':active');
-            return [active ? 1 : 0, active ? 'on' : ''];
+            return [active ? 1 : 0, active ? 'on' : '', active ? '⚫' : '⚪'];
         }
         """,
         Output("zero-state", "data"),
         Output("zero-btn", "className"),
+        Output("zero-btn", "children"),
         Input("zero-interval", "n_intervals"),
         prevent_initial_call=False,
     )
@@ -498,13 +499,14 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
-            if(n === undefined){ return [state, state ? 'on' : '']; }
+            if(n === undefined){ return [state, state ? 'on' : '', state ? '⚫' : '⚪']; }
             var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            return [newState, newState ? 'on' : '', newState ? '⚫' : '⚪'];
         }
         """,
         Output("motor-state", "data"),
         Output("motor-btn", "className"),
+        Output("motor-btn", "children"),
         Input("motor-btn", "n_clicks"),
         State("motor-state", "data"),
         prevent_initial_call=True,
@@ -514,13 +516,14 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
-            if(n === undefined){ return [state, state ? 'on' : '']; }
+            if(n === undefined){ return [state, state ? 'on' : '', state ? '⚫' : '⚪']; }
             var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            return [newState, newState ? 'on' : '', newState ? '⚫' : '⚪'];
         }
         """,
         Output("assist-state", "data"),
         Output("assist-btn", "className"),
+        Output("assist-btn", "children"),
         Input("assist-btn", "n_clicks"),
         State("assist-state", "data"),
         prevent_initial_call=True,
@@ -530,13 +533,14 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
-            if(n === undefined){ return [state, state ? 'on' : '']; }
+            if(n === undefined){ return [state, state ? 'on' : '', state ? '⚫' : '⚪']; }
             var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            return [newState, newState ? 'on' : '', newState ? '⚫' : '⚪'];
         }
         """,
         Output("k-state", "data"),
         Output("k-btn", "className"),
+        Output("k-btn", "children"),
         Input("k-btn", "n_clicks"),
         State("k-state", "data"),
         prevent_initial_call=True,

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -30,14 +30,19 @@ body {
 }
 
 .controls button {
-    padding: 10px 20px;
+    width: 40px;
+    height: 40px;
+    padding: 0;
     border: none;
-    border-radius: 20px;
+    border-radius: 50%;
     background: #ffffff;
     color: #000000;
-    font-size: 16px;
+    font-size: 20px;
     cursor: pointer;
-    transition: background 0.2s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, transform 0.1s;
 }
 
 
@@ -48,18 +53,21 @@ body {
 
 .controls button:active {
     background: #e0e0e0;
+    transform: scale(0.95);
 }
 
 .controls button.on {
-    background: #0c745f;
+    background: #000000;
+    color: #ffffff;
 }
 
 .controls button.on:hover {
-    background: #0b6554;
+    background: #222222;
 }
 
 .controls button.on:active {
-    background: #094e42;
+    background: #444444;
+    transform: scale(0.95);
 }
 .plots {
     display: flex;
@@ -112,7 +120,7 @@ body {
     background: #f0f0f0;
 }
 .tab-buttons button.active {
-    background: #10a37f;
+    background: #000000;
     color: #ffffff;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
## Summary
- update button labels to unicode icons
- make buttons circular with color feedback
- turn tab selection colors black and white

## Testing
- `python -m py_compile app.py`
- `python -m py_compile frontend_dash.py main.py app_test.py data_handler.py listener.py sse_server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*