### PR TITLE
Fix missing glow and remove plot markers

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,13 +416,12 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                                 go.Scatter(
                                                     x=[],
                                                     y=[],
-                                                    mode="lines+markers",
+                                                    mode="lines",
                                                     name=f"pressure_{i}",
                                                     line=dict(
                                                         width=3,
                                                         color=COLOR_CYCLE[(i - 1) % len(COLOR_CYCLE)],
                                                     ),
-                                                    marker=dict(symbol="circle", size=6),
                                                 )
                                                 for i in range(1, 9)
                                             ],
@@ -468,13 +467,12 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                                                 go.Scatter(
                                                     x=[],
                                                     y=[],
-                                                    mode="lines+markers",
+                                                    mode="lines",
                                                     name=f"imu_{i}",
                                                     line=dict(
                                                         width=3,
                                                         color=COLOR_CYCLE[(i - 1) % len(COLOR_CYCLE)],
                                                     ),
-                                                    marker=dict(symbol="circle", size=6),
                                                 )
                                                 for i in range(1, 4)
                                             ],

--- a/app_test.py
+++ b/app_test.py
@@ -85,10 +85,9 @@ def update_figures(_):  # noqa: D401
         go.Scatter(
             x=times,
             y=df["ankle_angle"],
-            mode="lines+markers",
+            mode="lines",
             name="ankle_angle",
             line=dict(width=3, color="#0B74FF"),
-            marker=dict(symbol="circle", size=6),
         )
     )
     fig_ankle.update_yaxes(
@@ -121,10 +120,9 @@ def update_figures(_):  # noqa: D401
                 go.Scatter(
                     x=times,
                     y=df[key],
-                    mode="lines+markers",
+                    mode="lines",
                     name=key,
                     line=dict(width=3, color=color),
-                    marker=dict(symbol="circle", size=6),
                 )
             )
     fig_press.update_yaxes(

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -146,6 +146,7 @@ body {
 }
 
 .js-plotly-plot .scatterlayer .js-line {
-    /* Glow effect applied via assets/glow.js */
+    /* Base glow in case JS fails */
+    filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.25));
 }
 

--- a/assets/glow.js
+++ b/assets/glow.js
@@ -27,4 +27,6 @@ if (document.readyState === 'loading') {
 
 // Re-apply glow after plots update (e.g., when data extends)
 document.addEventListener('plotly_afterplot', applyGlow);
+document.addEventListener('plotly_restyle', applyGlow);
+document.addEventListener('plotly_redraw', applyGlow);
 


### PR DESCRIPTION
## Summary
- drop circular markers from pressure and IMU traces
- provide a fallback glow style via CSS
- ensure glow.js re-applies after plot updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*