### PR TITLE
Throttle status printing

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ def start_udp_listener(
     sock.setblocking(True)
     sock.settimeout(1.0)  # add right after sock.setblocking(True)
     packets_rcvd = 0  # counter
+    last_status = time.time()
     print(
         f"Listening for data on {cfg['udp']['listen_host']}:{cfg['udp']['listen_port']}"
     )
@@ -191,9 +192,13 @@ def start_udp_listener(
         }
         try:
             event_q.put_nowait(sample)
-            if packets_rcvd % 100 == 0:
-                # Every 100 packets give a small hint that data flows.
-                print(f"Enqueued {packets_rcvd} samples. Queue size: {event_q.qsize()}")
+            now = time.time()
+            if now - last_status >= 10.0:
+                # Periodic hint that data is flowing
+                print(
+                    f"Enqueued {packets_rcvd} samples. Queue size: {event_q.qsize()}"
+                )
+                last_status = now
         except Exception:
             # queue full – drop sample to avoid blocking UDP thread
             pass

--- a/listener.py
+++ b/listener.py
@@ -70,6 +70,7 @@ def start_udp_listener(cfg: Dict[str, Any], buffer: Deque[Dict[str, float]]) -> 
     last_flush_wall: float = time.time()
 
     packets_rcvd = 0
+    last_status = time.time()
 
     with open(LOG_FILE, "w", encoding="utf-8") as f:
         f.write(",".join(HEADER_FIELDS) + "\n")
@@ -106,9 +107,11 @@ def start_udp_listener(cfg: Dict[str, Any], buffer: Deque[Dict[str, float]]) -> 
             with open(LOG_FILE, "w", encoding="utf-8") as f:
                 f.write(",".join(HEADER_FIELDS) + "\n")
                 f.write("\n".join(csv_buffer))
-
-        if packets_rcvd % 100 == 0:
-            print(f"[listener] Received {packets_rcvd} packets – csv rows {len(csv_buffer)}")
+        if now_wall - last_status >= 10.0:
+            last_status = now_wall
+            print(
+                f"[listener] Received {packets_rcvd} packets – csv rows {len(csv_buffer)}"
+            )
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reduce console output in `app.py` and `listener.py`
- print status messages at most once every 10 seconds

## Testing
- `python -m py_compile $(git ls-files '*.py')`