### PR TITLE
Limit CSV file to last 1000 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ pip install -r requirements.txt
 7. Open `http://127.0.0.1:8050` in your browser. You should see live plots once Simulink starts streaming.
 8. If the Simulink board is unreachable the app automatically generates fake
    data so you can exercise the dashboard offline.
+9. Logged CSV data is treated as a rolling buffer—only the latest 1000 samples
+   are kept on disk.
 
 ---
 


### PR DESCRIPTION
## Summary
- keep `DataLogger` rows in a ring buffer and rewrite the CSV on flush
- document the rolling CSV buffer in the README

## Testing
- `python -m pip --version`