### PR TITLE
Add gait percentage graph

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -75,7 +75,7 @@ button {
     gap: 20px;
 }
 .plots .dash-graph {
-    flex: 1 1 45%;
+    flex: 1 1 30%;
     min-width: 0;
     padding: 10px;
     border-radius: 12px;


### PR DESCRIPTION
## Summary
- visualize new `gait_percentage` signal
- generate fake gait data when offline
- stream gait data over SSE
- update dashboard layout to show three graphs side by side

## Testing
- `python -m py_compile app.py`
- `pytest -q`