### PR TITLE
Implement segmented pill-style tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,8 +348,10 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             html.Div(EventSource(id="es", url="/events"), style={"display": "none"}),
             dcc.Store(id="tab-index", data=0),
             html.Div(
+                id="tabbar",
                 className="tab-buttons",
                 children=[
+                    html.Span(id="tabHighlight", style={"transform": "translateX(0%)"}),
                     html.Button("Angle + Torque", id="tab-angle", n_clicks=0, className="active"),
                     html.Button("Insole", id="tab-insole", n_clicks=0),
                 ],
@@ -658,12 +660,18 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                 var width = cont.clientWidth;
                 cont.scrollTo({left: width * idx, behavior: 'smooth'});
             }
-            return [idx, idx===0 ? 'active' : '', idx===1 ? 'active' : ''];
+            return [
+                idx,
+                idx===0 ? 'active' : '',
+                idx===1 ? 'active' : '',
+                {transform: 'translateX(' + (idx*100) + '%)'}
+            ];
         }
         """,
         Output("tab-index", "data"),
         Output("tab-angle", "className"),
         Output("tab-insole", "className"),
+        Output("tabHighlight", "style"),
         Input("tab-angle", "n_clicks"),
         Input("tab-insole", "n_clicks"),
         State("tab-index", "data"),

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -97,31 +97,39 @@ button {
 }
 
 .tab-buttons {
+    position: relative;
     display: flex;
-    justify-content: center;
-    margin-bottom: 10px;
+    overflow: hidden;
+    margin: 0 auto 10px;
+    width: 90%;
+    border-radius: 9999px;
+    border: 1px solid #E5E7EB;
+    background: #ffffff;
+}
+
+#tabHighlight {
+    position: absolute;
+    inset: 0;
+    width: 50%;
+    border-radius: inherit;
+    background: #000000;
+    transition: transform .25s ease;
 }
 
 .tab-buttons button {
-    flex: 1 1 50%;
+    flex: 1 1 0;
+    position: relative;
+    z-index: 1;
     padding: 8px 16px;
-    margin: 0 4px;
-    border: 1px solid #cccccc;
-    border-radius: 20px;
-    background: #ffffff;
-    color: #000000;
+    border: none;
+    background: none;
+    color: #4b5563;
     cursor: pointer;
     font-size: 16px;
-    transition: background 0.2s, box-shadow 0.2s;
 }
 
-.tab-buttons button:hover {
-    background: #f0f0f0;
-}
 .tab-buttons button.active {
-    background: #000000;
     color: #ffffff;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
 .swipe-container {


### PR DESCRIPTION
## Summary
- add 90% width pill-style tab container with sliding highlight
- include highlight span in layout
- move highlight on tab change with clientside callback

## Testing
- `python -m py_compile app.py main.py`