### PR TITLE
Adjust tab layout and sync highlight with scroll

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -73,6 +73,8 @@ button {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 20px;
+    width: 80%;  /* restrict total width */
+    margin: 0 auto; /* center within the page */
 }
 .plots .dash-graph {
     flex: 1 1 30%;
@@ -96,21 +98,33 @@ button {
     display: none;
 }
 
+# The tab bar containing the pill highlight
 .tab-buttons {
     position: relative;
     display: flex;
     overflow: hidden;
     margin: 0 auto 10px;
-    width: 90%;
+    width: 80%; /* reduce width from 90% */
     border-radius: 9999px;
     border: 1px solid #E5E7EB;
     background: #ffffff;
 }
 
+# Sliding pill used to indicate the active tab
+# Width reduced to ~25% to match request
+# Position will be controlled via transform from callbacks/JS
+# so only the width is defined here
+# (the "inset: 0" ensures the pill stays within the tab bar)
+# 25% keeps the pill noticeably smaller than a full tab
+# while remaining responsive.
+#
+# style tuned according to user request
+#   - width: 25% of the tab bar
+#   - same border radius and transition as before
 #tabHighlight {
     position: absolute;
     inset: 0;
-    width: 50%;
+    width: 25%;
     border-radius: inherit;
     background: #000000;
     transition: transform .25s ease;

--- a/assets/tab-sync.js
+++ b/assets/tab-sync.js
@@ -1,0 +1,22 @@
+(function(){
+    function updateFromScroll(){
+        var cont = document.querySelector('.swipe-container');
+        var highlight = document.getElementById('tabHighlight');
+        var angleBtn = document.getElementById('tab-angle');
+        var insoleBtn = document.getElementById('tab-insole');
+        if(!cont || !highlight || !angleBtn || !insoleBtn){ return; }
+        var idx = Math.round(cont.scrollLeft / cont.clientWidth);
+        if(idx < 0){ idx = 0; }
+        if(idx > 1){ idx = 1; }
+        highlight.style.transform = 'translateX(' + (idx*100) + '%)';
+        angleBtn.classList.toggle('active', idx === 0);
+        insoleBtn.classList.toggle('active', idx === 1);
+    }
+    document.addEventListener('DOMContentLoaded', function(){
+        var cont = document.querySelector('.swipe-container');
+        if(!cont) return;
+        cont.addEventListener('scroll', function(){
+            window.requestAnimationFrame(updateFromScroll);
+        });
+    });
+})();


### PR DESCRIPTION
## Summary
- shrink tab highlight to 25%
- make tab bar and plot containers 80% wide
- sync the tab highlight with scroll events via new JS

## Testing
- `python -m py_compile app.py main.py`