### PR TITLE
Fix swipe layout and pill selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -656,15 +656,21 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
                 else if(id === 'tab-insole'){ idx = 1; }
             }
             var cont = document.querySelector('.swipe-container');
+            var highlight = document.getElementById('tabHighlight');
+            var offset = 0;
             if(cont){
                 var width = cont.clientWidth;
                 cont.scrollTo({left: width * idx, behavior: 'smooth'});
+                if(highlight){
+                    var tabWidth = width / 2;
+                    offset = idx * tabWidth + (tabWidth - highlight.offsetWidth)/2;
+                }
             }
             return [
                 idx,
                 idx===0 ? 'active' : '',
                 idx===1 ? 'active' : '',
-                {transform: 'translateX(' + (idx*100) + '%)'}
+                {transform: 'translateX(' + offset + 'px)'}
             ];
         }
         """,

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -73,8 +73,6 @@ button {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 20px;
-    width: 80%;  /* restrict total width */
-    margin: 0 auto; /* center within the page */
 }
 .plots .dash-graph {
     flex: 1 1 30%;
@@ -160,14 +158,15 @@ button {
 }
 
 .swipe-page {
-    flex: 0 0 100%;
+    flex: 0 0 80%;
     scroll-snap-align: start;
     padding: 20px;
     background: #ffffff;
     border-radius: 16px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    margin: 0 10%;
     margin-bottom: 10px;
-    max-width: 100%;
+    max-width: 80%;
     box-sizing: border-box;
 }
 

--- a/assets/tab-sync.js
+++ b/assets/tab-sync.js
@@ -8,7 +8,9 @@
         var idx = Math.round(cont.scrollLeft / cont.clientWidth);
         if(idx < 0){ idx = 0; }
         if(idx > 1){ idx = 1; }
-        highlight.style.transform = 'translateX(' + (idx*100) + '%)';
+        var tabWidth = cont.clientWidth / 2;
+        var offset = idx * tabWidth + (tabWidth - highlight.offsetWidth)/2;
+        highlight.style.transform = 'translateX(' + offset + 'px)';
         angleBtn.classList.toggle('active', idx === 0);
         insoleBtn.classList.toggle('active', idx === 1);
     }
@@ -18,5 +20,6 @@
         cont.addEventListener('scroll', function(){
             window.requestAnimationFrame(updateFromScroll);
         });
+        updateFromScroll();
     });
 })();


### PR DESCRIPTION
## Summary
- keep plots container full width
- shrink each swipe page to 80% with side margins
- update pill highlight JS to account for new width
- match clientside callback logic in app.py

## Testing
- `python -m py_compile app.py main.py` *(fails: ModuleNotFoundError: No module named 'yaml')*