### PR TITLE
Fix tab pill script timing

### DIFF
--- a/assets/tab-sync.js
+++ b/assets/tab-sync.js
@@ -5,21 +5,34 @@
         var angleBtn = document.getElementById('tab-angle');
         var insoleBtn = document.getElementById('tab-insole');
         if(!cont || !highlight || !angleBtn || !insoleBtn){ return; }
+
         var idx = Math.round(cont.scrollLeft / cont.clientWidth);
         if(idx < 0){ idx = 0; }
         if(idx > 1){ idx = 1; }
+
         var tabWidth = cont.clientWidth / 2;
-        var offset = idx * tabWidth + (tabWidth - highlight.offsetWidth)/2;
+        var pillWidth = cont.clientWidth * 0.25; // match CSS width
+        var offset = idx * tabWidth + (tabWidth - pillWidth) / 2;
+
+        highlight.style.width = pillWidth + 'px';
         highlight.style.transform = 'translateX(' + offset + 'px)';
+
         angleBtn.classList.toggle('active', idx === 0);
         insoleBtn.classList.toggle('active', idx === 1);
     }
-    document.addEventListener('DOMContentLoaded', function(){
+
+    function init(){
         var cont = document.querySelector('.swipe-container');
         if(!cont) return;
         cont.addEventListener('scroll', function(){
             window.requestAnimationFrame(updateFromScroll);
         });
         updateFromScroll();
-    });
+    }
+
+    if(document.readyState === 'loading'){
+        document.addEventListener('DOMContentLoaded', init);
+    }else{
+        init();
+    }
 })();


### PR DESCRIPTION
## Summary
- adjust tab highlight script so pill stays in sync with the scroll container even if DOMContentLoaded has already fired
- compute pill width from container size and set it directly

## Testing
- `python -m py_compile app.py main.py`
