### PR TITLE
Improve tab alignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -658,19 +658,20 @@ def build_dash_app(cfg: Dict[str, Any], data_buf: Deque[Dict[str, float]]) -> da
             var cont = document.querySelector('.swipe-container');
             var highlight = document.getElementById('tabHighlight');
             var offset = 0;
+            var width = 0;
             if(cont){
-                var width = cont.clientWidth;
+                width = cont.clientWidth;
                 cont.scrollTo({left: width * idx, behavior: 'smooth'});
                 if(highlight){
                     var tabWidth = width / 2;
-                    offset = idx * tabWidth + (tabWidth - highlight.offsetWidth)/2;
+                    offset = idx * tabWidth;
                 }
             }
             return [
                 idx,
                 idx===0 ? 'active' : '',
                 idx===1 ? 'active' : '',
-                {transform: 'translateX(' + offset + 'px)'}
+                {transform: 'translateX(' + offset + 'px)', width: (width/2)+'px'}
             ];
         }
         """,

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -102,7 +102,7 @@ button {
     display: flex;
     overflow: hidden;
     margin: 0 auto 10px;
-    width: 80%; /* reduce width from 90% */
+    width: 80%;
     border-radius: 9999px;
     border: 1px solid #E5E7EB;
     background: #ffffff;
@@ -121,10 +121,12 @@ button {
 #   - same border radius and transition as before
 #tabHighlight {
     position: absolute;
-    inset: 0;
-    width: 25%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 50%;
     border-radius: inherit;
-    background: #000000;
+    background: #1f2937;
     transition: transform .25s ease;
 }
 
@@ -149,7 +151,9 @@ button {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
-    padding: 0 10px;
+    width: 80%;
+    margin: 0 auto;
+    padding: 0;
     scrollbar-width: none; /* hide scrollbar in Firefox */
     -ms-overflow-style: none; /* hide scrollbar in IE/Edge */
 }
@@ -158,15 +162,13 @@ button {
 }
 
 .swipe-page {
-    flex: 0 0 80%;
+    flex: 0 0 100%;
     scroll-snap-align: start;
     padding: 20px;
     background: #ffffff;
     border-radius: 16px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-    margin: 0 10%;
     margin-bottom: 10px;
-    max-width: 80%;
     box-sizing: border-box;
 }
 

--- a/assets/tab-sync.js
+++ b/assets/tab-sync.js
@@ -11,10 +11,8 @@
         if(idx > 1){ idx = 1; }
 
         var tabWidth = cont.clientWidth / 2;
-        var pillWidth = cont.clientWidth * 0.25; // match CSS width
-        var offset = idx * tabWidth + (tabWidth - pillWidth) / 2;
-
-        highlight.style.width = pillWidth + 'px';
+        var offset = idx * tabWidth;
+        highlight.style.width = tabWidth + 'px';
         highlight.style.transform = 'translateX(' + offset + 'px)';
 
         angleBtn.classList.toggle('active', idx === 0);


### PR DESCRIPTION
## Summary
- update tab highlight CSS
- center swipe container
- adjust swipe JS to use tab width
- keep highlight width in callback for JS-less fallback

## Testing
- `python -m py_compile app.py main.py`
- `python app.py` *(fails: No module named 'yaml')*