### PR TITLE
Add statusword driven motor button display

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,4 +54,4 @@ signals:
   heel_strike: 26
   assistance_level: 27
   estimated_ankle_moment: 28
-  empty: 29
+  statusword: 29


### PR DESCRIPTION
## Summary
- map YAML index 29 to `statusword`
- include `statusword` in SSE samples
- generate fake statusword data
- colour motor control button based on status word value

## Testing
- `python -m py_compile app.py`
