### PR TITLE
Fix x-axis autorange

### DIFF
--- a/app.py
+++ b/app.py
@@ -705,7 +705,10 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                             var xData = gd.data[0].x;
                             var latest = xData[xData.length - 1];
                             if(typeof latest !== 'number') latest = Number(latest);
-                            Plotly.relayout(gd, {'xaxis.range': [latest - window_sec, latest]});
+                            Plotly.relayout(gd, {
+                                'xaxis.autorange': false,
+                                'xaxis.range': [latest - window_sec, latest]
+                            });
                         }
                     });
                 }
@@ -798,7 +801,10 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                 var gd = document.getElementById(id);
                 if(gd) {
                     try {
-                        Plotly.relayout(gd, {'xaxis.range': xrange});
+                        Plotly.relayout(gd, {
+                            'xaxis.autorange': false,
+                            'xaxis.range': xrange
+                        });
                     } catch(e) { /* ignore before initial render */ }
                 }
             });


### PR DESCRIPTION
## Summary
- disable autorange when updating realtime plots to keep window size constant

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6839f0ffe1f0832f98a0e56bda48b3f9