### PR TITLE
Fix window history when switching

### DIFF
--- a/app.py
+++ b/app.py
@@ -830,7 +830,9 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
 
             var winSec = (typeof window_sec === 'number') ? window_sec : ${default_window};
             var dt = (typeof avg_dt === 'number') ? avg_dt : 1.0/${sample_rate};
-            var maxPoints = Math.round(winSec / dt);
+            // Always keep at least the default window of data so switching
+            // from a shorter to a longer window still shows recent history.
+            var maxPoints = Math.round(${default_window} / dt);
 
             // Slide x-axis window to show only the last window_sec seconds
             var latestT = t[t.length - 1];


### PR DESCRIPTION
## Summary
- always keep at least the default window worth of data on the client
- prevents losing history when changing from 2s to 10s view

## Testing
- `python -m py_compile app.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683a02344cf8832f830d51aa6c94b9b6