### PR TITLE
Serve dashboard on localhost when Simulink unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ pip install -r requirements.txt
    ```bash
    python app.py  # auto-reloads in development
    ```
-7. Open `http://192.168.7.15:8050` in your browser. You should see live plots once Simulink starts streaming.
-8. If the Simulink board is unreachable the app automatically generates fake
-   data so you can exercise the dashboard offline.
-9. Incoming data is kept in memory only—nothing is written to CSV.
+7. Open `http://192.168.7.15:8050` in your browser. You should see live plots once
+   Simulink starts streaming. If the board cannot be reached the app falls back to
+   `http://127.0.0.1:8050` and generates fake data so you can exercise the
+   dashboard offline.
+8. Incoming data is kept in memory only—nothing is written to CSV.
 
 ---
 


### PR DESCRIPTION
## Summary
- if Simulink send host cannot be reached, start fake data generator and serve dashboard on `127.0.0.1`
- document fallback server address in README

## Testing
- `python -m py_compile app.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683db1504c54832f8f93dfbc67756f27