### PR TITLE
Remove time plot and enforce tab snapping

### DIFF
--- a/app.py
+++ b/app.py
@@ -523,39 +523,6 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                                         ),
                                         config={"displayModeBar": False, "staticPlot": True},
                                     ),
-                                    dcc.Graph(
-                                        id="time-graph",
-                                        style={"height": "360px"},
-                                        figure=go.Figure(
-                                            data=make_line_with_marker(
-                                                "time", "#D62728"
-                                            ),
-                                            layout=dict(
-                                                yaxis=dict(
-                                                    title="Time (s)",
-                                                    gridcolor="#EEF1F4",
-                                                    gridwidth=2,
-                                                    zeroline=True,
-                                                    zerolinecolor="#EEF1F4",
-                                                    zerolinewidth=2,
-                                                    tickfont=dict(size=16),
-                                                ),
-                                                xaxis=dict(
-                                                    showgrid=False,
-                                                    tickfont=dict(size=16),
-                                                ),
-                                                title=None,
-                                                showlegend=False,
-                                                plot_bgcolor="rgba(0,0,0,0)",
-                                                paper_bgcolor="rgba(0,0,0,0)",
-                                                font=dict(
-                                                    family="IBM Plex Sans Condensed",
-                                                    size=18,
-                                                ),
-                                            ),
-                                        ),
-                                        config={"displayModeBar": False, "staticPlot": True},
-                                    ),
                                 ],
                             )
                         ],
@@ -714,7 +681,7 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
             if(!msg){
                 // No new data – adjust x-range using existing points
                 if(typeof window_sec === 'number'){
-                    ['torque','ankle','gait','press','imu','time-graph'].forEach(function(id){
+                    ['torque','ankle','gait','press','imu'].forEach(function(id){
                         var gd = document.getElementById(id);
                         if(gd && gd.data && gd.data.length && gd.data[0].x && gd.data[0].x.length){
                             var xData = gd.data[0].x;
@@ -727,18 +694,18 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                         }
                     });
                 }
-                return [null, null, null, null, null, null, null];
+                return [null, null, null, null, null, null];
             }
 
             var json_str = (typeof msg === 'string') ? msg : (msg && msg.data);
-            if(!json_str){ return [null, null, null, null, null, null, null]; }
+            if(!json_str){ return [null, null, null, null, null, null]; }
 
             var payload;
             try {
                 payload = JSON.parse(json_str);
             } catch(e){
                 console.error('failed to parse SSE payload', e);
-                return [null, null, null, null, null, null, null];
+                return [null, null, null, null, null, null];
             }
 
             var t = payload.t;
@@ -776,7 +743,6 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
             var gait_payload = {x:[t], y:[gait]};
             var press_payload = {x:Array(8).fill(t), y:pressT};
             var imu_payload = {x:Array(3).fill(t), y:imuT};
-            var time_payload = {x:[t], y:[t]};
 
             var colorReady = '#FFD280';  // light orange
             var colorFault = '#FF9E9E';  // light red
@@ -814,7 +780,7 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
             var xrange = [latestT - winSec, latestT];
 
             // Apply relayout on each graph individually (if already rendered)
-            ['torque', 'ankle', 'gait', 'press', 'imu', 'time-graph'].forEach(function(id) {
+            ['torque', 'ankle', 'gait', 'press', 'imu'].forEach(function(id) {
                 var gd = document.getElementById(id);
                 if(gd) {
                     try {
@@ -831,7 +797,6 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                 [gait_payload, [0], maxPoints],
                 [press_payload, [0,2,4,6,8,10,12,14], maxPoints],
                 [imu_payload, [0,2,4], maxPoints],
-                [time_payload, [0], maxPoints],
                 btn_style
             ];
         }
@@ -844,7 +809,6 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
         Output("gait", "extendData"),
         Output("press", "extendData"),
         Output("imu", "extendData"),
-        Output("time-graph", "extendData"),
         Output("motor-btn", "style"),
         Input("es", "message"),
         Input("window-sec", "data"),

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -145,7 +145,7 @@ button {
     display: flex;
     overflow-x: auto; /* allow horizontal scrolling for tab switch */
     overflow-y: hidden; /* disable vertical scrolling */
-    scroll-snap-type: none;
+    scroll-snap-type: x mandatory;
     width: 90%;
     margin: 24px auto 24px auto;
     padding: 0;
@@ -158,6 +158,7 @@ button {
 .swipe-page {
     flex: 0 0 100%;
     scroll-snap-align: start;
+    scroll-snap-stop: always;
     padding: 2%;
     background: #ffffff;
     border-radius: 16px;


### PR DESCRIPTION
## Summary
- remove unused Time graph from second tab
- update SSE graph update callback accordingly
- enable scroll snapping for tab container

## Testing
- `python -m py_compile app.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db5524dbc832f9556b767d03dd927