### PR TITLE
Relocate time range buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -311,6 +311,18 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
             html.Div(EventSource(id="es", url="/events"), style={"display": "none"}),
             dcc.Store(id="tab-index", data=0),
             html.Div(
+                className="controls-dock",
+                children=[
+                    html.Div(
+                        className="controls",
+                        children=[
+                            html.Button("2s", id="window-2-btn", n_clicks=0),
+                            html.Button("10s", id="window-10-btn", n_clicks=0),
+                        ],
+                    )
+                ],
+            ),
+            html.Div(
                 className="swipe-container",
                 children=[
                     html.Div(
@@ -550,13 +562,6 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
                             html.Button("k", id="k-btn", n_clicks=0),
                         ],
                     ),
-                    html.Div(
-                        className="controls",
-                        children=[
-                            html.Button("2s", id="window-2-btn", n_clicks=0),
-                            html.Button("10s", id="window-10-btn", n_clicks=0),
-                        ],
-                    )
                 ],
             ),
         ],


### PR DESCRIPTION
## Summary
- move window selection buttons above the plots
- keep control buttons on bottom
- use existing `.controls` styles for even spacing

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683db859aa24832f9f2f45eeeeff49de