### PR TITLE
Plot command torque

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,5 +53,5 @@ signals:
   actual_torque: 25
   heel_strike: 26
   assistance_level: 27
-  estimated_ankle_moment: 28
+  command_torque: 28
   statusword: 29


### PR DESCRIPTION
## Summary
- rename `estimated_ankle_moment` signal to `command_torque`
- send and plot `command_torque` together with actual torque
- show legends for actual and command torque
- switch torque axis label to `Torque (Nm)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683db99bff7c832f83daad14c09612a3