### PR TITLE
Update legend labels without underscores

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,24 +71,25 @@ _client_lock = threading.Lock()
 # Helper to create a line trace with a separate legend marker
 def make_line_with_marker(name: str, color: str) -> list[go.Scattergl]:
     """Return a line trace and a marker-only trace for the legend."""
+    clean_name = name.replace("_", " ")
     line = go.Scattergl(
         x=[],
         y=[],
         mode="lines",
-        name=name,
+        name=clean_name,
         line=dict(width=3, color=color),
-        legendgroup=name,
+        legendgroup=clean_name,
         showlegend=False,
-        )
+    )
     marker = go.Scattergl(
         x=[None],
         y=[None],
         mode="markers",
-        name=name,
+        name=clean_name,
         marker=dict(size=8, color=color, symbol="circle"),
-        legendgroup=name,
+        legendgroup=clean_name,
         showlegend=True,
-        )
+    )
     return [line, marker]
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize legend text by removing underscores in `make_line_with_marker`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683dbce77560832f99b65bc5fd4156f5