### PR TITLE
Implement hold-to-activate buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -604,9 +604,13 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
+            var btn = document.getElementById('motor-btn');
+            var dur = btn ? parseFloat(btn.dataset.holdDuration || '0') : 0;
             if(n === undefined){ return [state, state ? 'on' : '']; }
-            var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            btn.dataset.holdDuration = '0';
+            if(state === 1){ return [0, '']; }
+            if(dur >= 2000){ return [1, 'on']; }
+            return [state, state ? 'on' : ''];
         }
         """,
         Output("motor-state", "data"),
@@ -620,9 +624,13 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
+            var btn = document.getElementById('assist-btn');
+            var dur = btn ? parseFloat(btn.dataset.holdDuration || '0') : 0;
             if(n === undefined){ return [state, state ? 'on' : '']; }
-            var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            btn.dataset.holdDuration = '0';
+            if(state === 1){ return [0, '']; }
+            if(dur >= 2000){ return [1, 'on']; }
+            return [state, state ? 'on' : ''];
         }
         """,
         Output("assist-state", "data"),
@@ -636,9 +644,13 @@ def build_dash_app(cfg: Dict[str, Any]) -> dash.Dash:
         """
         function(n, state){
             if(typeof state !== 'number') state = 0;
+            var btn = document.getElementById('k-btn');
+            var dur = btn ? parseFloat(btn.dataset.holdDuration || '0') : 0;
             if(n === undefined){ return [state, state ? 'on' : '']; }
-            var newState = 1 - state;
-            return [newState, newState ? 'on' : ''];
+            btn.dataset.holdDuration = '0';
+            if(state === 1){ return [0, '']; }
+            if(dur >= 2000){ return [1, 'on']; }
+            return [state, state ? 'on' : ''];
         }
         """,
         Output("k-state", "data"),

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -55,6 +55,15 @@ button {
     margin: 0 4px;
 }
 
+@keyframes hold-progress {
+    from { background: #ffffff; color: #000000; }
+    to { background: #000000; color: #ffffff; }
+}
+
+.controls button.holding:not(.on) {
+    animation: hold-progress 2s linear forwards;
+}
+
 .controls button:hover {
     background: #f0f0f0;
 }

--- a/assets/hold.js
+++ b/assets/hold.js
@@ -1,0 +1,32 @@
+// Manage hold-to-activate behaviour for toggle buttons
+function setupHoldButton(id){
+    var btn = document.getElementById(id);
+    if(!btn) return;
+    function start(){
+        btn.dataset.holdStart = Date.now();
+        btn.dataset.holdDuration = '0';
+        btn.classList.add('holding');
+    }
+    function end(){
+        if(!btn.dataset.holdStart) return;
+        var dur = Date.now() - parseInt(btn.dataset.holdStart, 10);
+        btn.dataset.holdDuration = String(dur);
+        btn.classList.remove('holding');
+        delete btn.dataset.holdStart;
+    }
+    function cancel(){
+        btn.dataset.holdDuration = '0';
+        btn.classList.remove('holding');
+        delete btn.dataset.holdStart;
+    }
+    btn.addEventListener('mousedown', start);
+    btn.addEventListener('touchstart', start);
+    btn.addEventListener('mouseup', end);
+    btn.addEventListener('touchend', end);
+    btn.addEventListener('mouseleave', cancel);
+    btn.addEventListener('touchcancel', cancel);
+}
+
+document.addEventListener('DOMContentLoaded', function(){
+    ['motor-btn','assist-btn','k-btn'].forEach(setupHoldButton);
+});


### PR DESCRIPTION
## Summary
- require holding toggle buttons for 2s to activate
- show an animated color transition while holding
- add clientside logic to track hold duration

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683dbfbb4900832f8c63d454085054ff