### PR TITLE
Fix button double-click detection

### DIFF
--- a/assets/double_click.js
+++ b/assets/double_click.js
@@ -16,6 +16,12 @@ function setupDoubleClickButton(id){
     });
 }
 
-document.addEventListener('DOMContentLoaded', function(){
+function initDoubleClickButtons(){
     ['zero-btn','motor-btn','assist-btn','k-btn'].forEach(setupDoubleClickButton);
-});
+}
+
+if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', initDoubleClickButtons);
+} else {
+    initDoubleClickButtons();
+}


### PR DESCRIPTION
## Summary
- ensure double-click handlers run even when DOM is ready before script loads

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683dcfedd828832f8e9c4601fec3d1a5