### PR TITLE
Switch project networking to TCP

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,12 @@
-# UDP connection parameters
-udp:
-  # IP address to bind the UDP listener ("0.0.0.0" means all interfaces)
-  listen_host: "0.0.0.0"
-  listen_port: 5431  # incoming data from Simulink
-
-  # Where to send outbound control packets (Simulink UDP Receive block)
-  send_host: "192.168.7.5"
-  send_port: 5431
+# TCP connection parameters
+tcp:
+  # Where the Simulink TCP Server is running
+  host: "192.168.7.5"
+  port: 5431
 
 # Packet definition
 packet:
-  # struct-format string describing the binary layout of a single UDP datagram.
+  # struct-format string describing the binary layout of a single TCP packet.
   # Below: 28 little-endian 32-bit floats (28 × 4 bytes = 112 bytes). Change to "<d" if you use doubles.
   format: "<30f"
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-One-shot UDP sender to test Simulink control signals.
+One-shot TCP sender to test Simulink control signals.
 
 This script packs four single-precision floats—`zero_signal`, `motor_signal`,
-`assistance_signal`, and `fixed_k_signal`—into a 16-byte datagram and sends it
-once to the IP/port defined under `udp.send_host` / `udp.send_port` in
+`assistance_signal`, and `fixed_k_signal`—into a 16-byte payload and sends it
+once to the IP/port defined under `tcp.host` / `tcp.port` in
 `config.yaml` (default: 192.168.7.5:5431).
 
 Run with custom values:
@@ -19,6 +19,7 @@ import asyncio
 import struct
 import yaml
 import logging
+import socket
 from typing import Dict, Any
 
 CONFIG_FILE = "config.yaml"
@@ -31,17 +32,16 @@ def load_config(path: str = CONFIG_FILE) -> Dict[str, Any]:
 
 
 async def send_packet(payload: bytes, host: str, port: int) -> None:
-    """Send *payload* to *(host, port)* via UDP once and close the socket."""
-    loop = asyncio.get_running_loop()
-    transport, _ = await loop.create_datagram_endpoint(
-        asyncio.DatagramProtocol,
-        remote_addr=(host, port),
-    )
+    """Send *payload* to *(host, port)* via TCP and close the connection."""
+    reader, writer = await asyncio.open_connection(host, port)
+    sock = writer.get_extra_info("socket")
+    if sock is not None:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     logging.info("Sending %d bytes to %s:%d", len(payload), host, port)
-    transport.sendto(payload)
-    # Give the event loop a tick to flush the packet
-    await asyncio.sleep(0.05)
-    transport.close()
+    writer.write(payload)
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
 
 
 def build_payload(args) -> bytes:
@@ -64,7 +64,7 @@ async def main_async() -> None:
     args = parse_args()
     payload = build_payload(args)
 
-    await send_packet(payload, cfg["udp"]["send_host"], cfg["udp"]["send_port"])
+    await send_packet(payload, cfg["tcp"]["host"], cfg["tcp"]["port"])
     logging.info("Done.")
 
 


### PR DESCRIPTION
## Summary
- update configuration for TCP host/port
- modify dashboard to use TCP and disable Nagle's buffering
- convert the helper command line sender to TCP

## Testing
- `python -m py_compile app.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f41c58b3c832fae06c2a683ff94d8