### PR TITLE
Handle graceful shutdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
-from threading import Thread
+from threading import Thread, Event
+import signal
 
 from utils import load_config, is_host_reachable
-from network import start_tcp_client, start_fake_data
+from network import start_tcp_client, start_fake_data, request_shutdown
 from dash_app import build_dash_app
 
 
@@ -11,9 +12,22 @@ if __name__ == "__main__":
     simulink_ok = is_host_reachable(cfg["tcp"]["host"])
     target_fn = start_tcp_client if simulink_ok else start_fake_data
 
-    listener_t = Thread(target=target_fn, args=(cfg,), daemon=True)
+    stop_event = Event()
+
+    def _handle_signal(signum, frame):
+        request_shutdown()
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    listener_t = Thread(target=target_fn, args=(cfg, stop_event))
     listener_t.start()
 
     dash_app = build_dash_app(cfg)
     host_addr = "192.168.7.15" if simulink_ok else "127.0.0.1"
-    dash_app.run(host=host_addr, port=8050, debug=False, use_reloader=False, threaded=True)
+    try:
+        dash_app.run(host=host_addr, port=8050, debug=False, use_reloader=False, threaded=True)
+    finally:
+        _handle_signal(None, None)
+        listener_t.join()


### PR DESCRIPTION
## Summary
- add shutdown event handling to network loops
- catch SIGINT/SIGTERM and terminate network thread

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f57ed065c832f9b3b47dd0bd5ee54